### PR TITLE
Fix of client events behavior

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -396,13 +396,7 @@ export class Client extends EventEmitter {
 
     options = options || {};
 
-    // Add extra headers
-    if (this.httpHeaders === null) {
-      headers = {};
-    } else {
-      for (const header in this.httpHeaders) { headers[header] = this.httpHeaders[header]; }
-      for (const attr in extraHeaders) { headers[attr] = extraHeaders[attr]; }
-    }
+
 
     // Allow the security object to add headers
     if (this.security && this.security.addHeaders) {
@@ -473,6 +467,14 @@ export class Client extends EventEmitter {
 
     this.emit('message', message, eid);
     this.emit('request', xml, eid);
+
+    // Add extra headers
+    if (this.httpHeaders === null) {
+      headers = {};
+    } else {
+      for (const header in this.httpHeaders) { headers[header] = this.httpHeaders[header]; }
+      for (const attr in extraHeaders) { headers[attr] = extraHeaders[attr]; }
+    }
 
     const tryJSONparse = (body) => {
       try {

--- a/test/header-rely-on-xml-test.js
+++ b/test/header-rely-on-xml-test.js
@@ -1,0 +1,59 @@
+'use strict';
+
+var soap = require('..'),
+  http = require('http'),
+  assert = require('assert');
+
+
+describe('testing adding header rely on completed xml', () => {
+  let server = null;
+  let hostname = '127.0.0.1';
+  let port = 15099;
+  let baseUrl = 'http://' + hostname + ':' + port;
+  const envelope = '<soap:Envelope xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"'
+    + ' xmlns:xsd="http://www.w3.org/2001/XMLSchema"'
+    + ' xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">'
+    + '<soap:Body><Response>Hello</Response></soap:Body></soap:Envelope>';
+
+  before(function (done) {
+    server = http.createServer(function (req, res) {
+      res.statusCode = 200;
+      res.write(envelope, 'utf8');
+      res.end();
+    }).listen(port, hostname, done);
+  });
+
+  after(function (done) {
+    server.close();
+    server = null;
+    done();
+  });
+
+  it('should add header to request, which created from xml before request', function (done) {
+    soap.createClient(__dirname + '/wsdl/complex/registration-common.wsdl', function (err, client) {
+      if (err) {
+        return void done(err);
+      }
+      assert.ok(client);
+
+      const testHeaderKey = 'testHeader';
+      let testHeaderValue;
+
+      client.on('request', (xml) => {
+        testHeaderValue = xml;
+        client.addHttpHeader(testHeaderKey, xml);
+      });
+
+      client.registerUser('', function (err, result) {
+
+        const header = result.request._header;
+        const headerKey = header.includes(testHeaderKey);
+        const headerValue = header.includes(testHeaderValue);
+
+        assert.equal(headerKey, true);
+        assert.equal(headerValue, true);
+        done();
+      });
+    }, baseUrl);
+  });
+});


### PR DESCRIPTION
Hi, I found node-soap really useful, but I had figured out some issue with client events behavior.

Its impossible to add to request additional http header, when "request" or "message" events were invoked because headers are already calculated when those events are emitted. Based on this issue I'm providing to you my pull request, with pretty simple and working solution. I added a test which describes behavior of request with my fix and without my fix. I consider, it will be really helpful for many developers.